### PR TITLE
重构了post，talk，nodes 中的 menu ，抽取成为组件

### DIFF
--- a/components/ListMenu.vue
+++ b/components/ListMenu.vue
@@ -41,7 +41,7 @@ const isSameYear = (a: Date | string | number, b: Date | string | number) => a &
         <span text-8em op10 absolute left--3rem top--2rem font-bold>{{ getYear(route.date) }}</span>
       </div>
       <div class="slide-enter" :style="`--enter-stage: ${idx}; --enter-step: 60ms;`">
-        <nuxt-link
+        <NuxtLink
           class="item block font-normal mb-6 mt-2 no-underline "
           :to="route.path"
         >
@@ -70,7 +70,7 @@ const isSameYear = (a: Date | string | number, b: Date | string | number) => a &
               <span v-if="route.duration" op80>· {{ route.duration }}</span>
             </div>
           </li>
-        </nuxt-link>
+        </NuxtLink>
       </div>
     </template>
   </ul>

--- a/components/ListMenu.vue
+++ b/components/ListMenu.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+const props = withDefaults(defineProps<{
+  name: string
+  showYear?: boolean
+}>(), {
+  showYear: false,
+})
+
+const { data: navigation } = await useAsyncData('navigation', () => fetchContentNavigation())
+
+const routers = navigation.value
+  ?.filter(i => i._path.startsWith(`/${props.name}`))[0]
+  .children
+  ?.sort((a, b) => +new Date(b.date) - +new Date(a.date))
+  .filter(i => !i._path.endsWith('.html'))
+  .map(i => ({
+    path: i._path,
+    title: i.title,
+    date: i.date,
+    lang: i.lang,
+    duration: i.duration,
+    recording: i.recording,
+    upcoming: i.upcoming,
+  }))
+
+// const posts = computed(() => routers.filter(i => !englishOnly.value || i.lang !== 'zh'))
+const getYear = (a: Date | string | number) => new Date(a).getFullYear()
+const isSameYear = (a: Date | string | number, b: Date | string | number) => a && b && getYear(a) === getYear(b)
+</script>
+
+<template>
+  <ul>
+    <template v-if="!routers?.length">
+      <div py2 op50>
+        { nothing here yet }
+      </div>
+    </template>
+
+    <template v-for="route, idx in routers" :key="route.path">
+      <div v-if="props.showYear && !isSameYear(route.date, routers![idx - 1]?.date)" relative h20 pointer-events-none class="slide-enter" style="--enter-stage: -2; --enter-step: 60ms;">
+        <span text-8em op10 absolute left--3rem top--2rem font-bold>{{ getYear(route.date) }}</span>
+      </div>
+      <div class="slide-enter" :style="`--enter-stage: ${idx}; --enter-step: 60ms;`">
+        <nuxt-link
+          class="item block font-normal mb-6 mt-2 no-underline "
+          :to="route.path"
+        >
+          <li class="no-underline">
+            <div class="title text-lg leading-1.2em">
+              <span
+                v-if="route.lang === 'zh' && !route.upcoming"
+                align-middle
+                class="text-xs border border-current rounded px-1 pb-0.2 md:ml--10.5 mr2"
+              >中文</span>
+              <span
+                v-if="route.upcoming"
+                align-middle
+                class="text-xs border rounded px-1 pb-0.2 md:ml--19 mr2 bg-lime/10 border-lime text-lime"
+              >upcoming</span>
+              <span align-middle>{{ route.title }}</span>
+              <span
+                v-if="route.recording"
+                align-middle mx1 text-red5
+                i-ri-movie-line
+                title="Has recording playback"
+              />
+            </div>
+            <div class="time opacity-50 text-sm">
+              {{ formatDate(route.date) }}
+              <span v-if="route.duration" op80>· {{ route.duration }}</span>
+            </div>
+          </li>
+        </nuxt-link>
+      </div>
+    </template>
+  </ul>
+</template>

--- a/content/notes/my-hegang-dream.md
+++ b/content/notes/my-hegang-dream.md
@@ -3,6 +3,7 @@ navigation.title: 我的鹤岗梦
 navigation.date: 2023-10-08T10:53:00.000+08:00
 navigation.lang: zh
 navigation.duration: 1min
+navigation.recording: true
 layout: 'default'
 ---
 

--- a/layouts/ListNotes.vue
+++ b/layouts/ListNotes.vue
@@ -47,50 +47,6 @@ const isSameYear = (a: Date | string | number, b: Date | string | number) => a &
 
 <template>
   <defaultVue>
-    <ul>
-      <template v-if="!routers?.length">
-        <div py2 op50>
-          { nothing here yet }
-        </div>
-      </template>
-
-      <template v-for="route, idx in routers" :key="route.path">
-        <div v-if="!isSameYear(route.date, routers![idx - 1]?.date)" relative h20 pointer-events-none class="slide-enter" style="--enter-stage: -2; --enter-step: 60ms;">
-          <span text-8em op10 absolute left--3rem top--2rem font-bold>{{ getYear(route.date) }}</span>
-        </div>
-        <div class="slide-enter" :style="`--enter-stage: ${idx}; --enter-step: 60ms;`">
-          <nuxt-link
-            class="item block font-normal mb-6 mt-2 no-underline "
-            :to="route.path"
-          >
-            <li class="no-underline">
-              <div class="title text-lg leading-1.2em">
-                <span
-                  v-if="route.lang === 'zh' && !route.upcoming"
-                  align-middle
-                  class="text-xs border border-current rounded px-1 pb-0.2 md:ml--10.5 mr2"
-                >中文</span>
-                <span
-                  v-if="route.upcoming"
-                  align-middle
-                  class="text-xs border rounded px-1 pb-0.2 md:ml--19 mr2 bg-lime/10 border-lime text-lime"
-                >upcoming</span>
-                <span align-middle>{{ route.title }}</span>
-                <span
-                  v-if="route.recording"
-                  align-middle mx1 text-red5
-                  i-ri-movie-line
-                  title="Has recording playback"
-                />
-              </div>
-              <div class="time opacity-50 text-sm">
-                {{ formatDate(route.date) }}
-                <span v-if="route.duration" op80>· {{ route.duration }}</span>
-              </div>
-            </li>
-          </nuxt-link>
-        </div>
-      </template>
-    </ul>
+    <ListMenu show-year name="notes" />
   </defaultVue>
 </template>

--- a/layouts/ListNotes.vue
+++ b/layouts/ListNotes.vue
@@ -1,8 +1,5 @@
 <script setup lang="ts">
 import defaultVue from './default.vue'
-import { formatDate } from '~/composables'
-
-const { data: navigation } = await useAsyncData('navigation', () => fetchContentNavigation())
 
 useHead({
   meta: [
@@ -24,25 +21,6 @@ useHead({
     },
   ],
 })
-
-const routers = navigation.value
-  ?.filter(i => i._path.startsWith('/notes'))[0]
-  .children
-  ?.sort((a, b) => +new Date(b.date) - +new Date(a.date))
-  .filter(i => !i._path.endsWith('.html'))
-  .map(i => ({
-    path: i._path,
-    title: i.title,
-    date: i.date,
-    lang: i.lang,
-    duration: i.duration,
-    recording: i.recording,
-    upcoming: i.upcoming,
-  }))
-
-// const posts = computed(() => routers.filter(i => !englishOnly.value || i.lang !== 'zh'))
-const getYear = (a: Date | string | number) => new Date(a).getFullYear()
-const isSameYear = (a: Date | string | number, b: Date | string | number) => a && b && getYear(a) === getYear(b)
 </script>
 
 <template>

--- a/layouts/ListPosts.vue
+++ b/layouts/ListPosts.vue
@@ -1,8 +1,5 @@
 <script setup lang="ts">
 import defaultVue from './default.vue'
-import { formatDate } from '~/composables'
-
-const { data: navigation } = await useAsyncData('navigation', () => fetchContentNavigation())
 
 useHead({
   meta: [
@@ -24,73 +21,10 @@ useHead({
     },
   ],
 })
-
-const routers = navigation.value
-  ?.filter(i => i._path.startsWith('/posts'))[0]
-  .children
-  ?.sort((a, b) => +new Date(b.date) - +new Date(a.date))
-  .filter(i => !i._path.endsWith('.html'))
-  .map(i => ({
-    path: i._path,
-    title: i.title,
-    date: i.date,
-    lang: i.lang,
-    duration: i.duration,
-    recording: i.recording,
-    upcoming: i.upcoming,
-  }))
-
-// const posts = computed(() => routers.filter(i => !englishOnly.value || i.lang !== 'zh'))
-const getYear = (a: Date | string | number) => new Date(a).getFullYear()
-const isSameYear = (a: Date | string | number, b: Date | string | number) => a && b && getYear(a) === getYear(b)
 </script>
 
 <template>
   <defaultVue>
-    <ul>
-      <template v-if="!routers?.length">
-        <div py2 op50>
-          { nothing here yet }
-        </div>
-      </template>
-
-      <template v-for="route, idx in routers" :key="route.path">
-        <div v-if="!isSameYear(route.date, routers![idx - 1]?.date)" relative h20 pointer-events-none class="slide-enter" style="--enter-stage: -2; --enter-step: 60ms;">
-          <span text-8em op10 absolute left--3rem top--2rem font-bold>{{ getYear(route.date) }}</span>
-        </div>
-        <div class="slide-enter" :style="`--enter-stage: ${idx}; --enter-step: 60ms;`">
-          <nuxt-link
-            class="item block font-normal mb-6 mt-2 no-underline "
-            :to="route.path"
-          >
-            <li class="no-underline">
-              <div class="title text-lg leading-1.2em">
-                <span
-                  v-if="route.lang === 'zh' && !route.upcoming"
-                  align-middle
-                  class="text-xs border border-current rounded px-1 pb-0.2 md:ml--10.5 mr2"
-                >中文</span>
-                <span
-                  v-if="route.upcoming"
-                  align-middle
-                  class="text-xs border rounded px-1 pb-0.2 md:ml--19 mr2 bg-lime/10 border-lime text-lime"
-                >upcoming</span>
-                <span align-middle>{{ route.title }}</span>
-                <span
-                  v-if="route.recording"
-                  align-middle mx1 text-red5
-                  i-ri-movie-line
-                  title="Has recording playback"
-                />
-              </div>
-              <div class="time opacity-50 text-sm">
-                {{ formatDate(route.date) }}
-                <span v-if="route.duration" op80>· {{ route.duration }}</span>
-              </div>
-            </li>
-          </nuxt-link>
-        </div>
-      </template>
-    </ul>
+    <ListMenu show-year name="posts" />
   </defaultVue>
 </template>

--- a/layouts/ListTalks.vue
+++ b/layouts/ListTalks.vue
@@ -1,8 +1,5 @@
 <script setup lang="ts">
 import defaultVue from './default.vue'
-import { formatDate } from '~/composables'
-
-const { data: navigation } = await useAsyncData('navigation', () => fetchContentNavigation())
 
 useHead({
   meta: [
@@ -24,73 +21,10 @@ useHead({
     },
   ],
 })
-
-const routers = navigation.value
-  ?.filter(i => i._path.startsWith('/talks'))[0]
-  .children
-  ?.sort((a, b) => +new Date(b.date) - +new Date(a.date))
-  .filter(i => !i._path.endsWith('.html'))
-  .map(i => ({
-    path: i._path,
-    title: i.title,
-    date: i.date,
-    lang: i.lang,
-    duration: i.duration,
-    recording: i.recording,
-    upcoming: i.upcoming,
-  }))
-
-// const posts = computed(() => routers.filter(i => !englishOnly.value || i.lang !== 'zh'))
-const getYear = (a: Date | string | number) => new Date(a).getFullYear()
-const isSameYear = (a: Date | string | number, b: Date | string | number) => a && b && getYear(a) === getYear(b)
 </script>
 
 <template>
   <defaultVue>
-    <ul>
-      <template v-if="!routers?.length">
-        <div py2 op50>
-          { nothing here yet }
-        </div>
-      </template>
-
-      <template v-for="route, idx in routers" :key="route.path">
-        <div v-if="!isSameYear(route.date, routers![idx - 1]?.date)" relative h20 pointer-events-none class="slide-enter" style="--enter-stage: -2; --enter-step: 60ms;">
-          <span text-8em op10 absolute left--3rem top--2rem font-bold>{{ getYear(route.date) }}</span>
-        </div>
-        <div class="slide-enter" :style="`--enter-stage: ${idx}; --enter-step: 60ms;`">
-          <nuxt-link
-            class="item block font-normal mb-6 mt-2 no-underline "
-            :to="route.path"
-          >
-            <li class="no-underline">
-              <div class="title text-lg leading-1.2em">
-                <span
-                  v-if="route.lang === 'zh' && !route.upcoming"
-                  align-middle
-                  class="text-xs border border-current rounded px-1 pb-0.2 md:ml--10.5 mr2"
-                >中文</span>
-                <span
-                  v-if="route.upcoming"
-                  align-middle
-                  class="text-xs border rounded px-1 pb-0.2 md:ml--19 mr2 bg-lime/10 border-lime text-lime"
-                >upcoming</span>
-                <span align-middle>{{ route.title }}</span>
-                <span
-                  v-if="route.recording"
-                  align-middle mx1 text-red5
-                  i-ri-movie-line
-                  title="Has recording playback"
-                />
-              </div>
-              <div class="time opacity-50 text-sm">
-                {{ formatDate(route.date) }}
-                <span v-if="route.duration" op80>· {{ route.duration }}</span>
-              </div>
-            </li>
-          </nuxt-link>
-        </div>
-      </template>
-    </ul>
+    <ListMenu show-year name="talk" />
   </defaultVue>
 </template>


### PR DESCRIPTION
cc @zhengke996

将重复的 menu 重构成为 [ListMenu](https://github.com/elonehoo/elonehoo.me/blob/reconstruct-lists/components/ListMenu.vue) 组件，通过参数 `name` 获取对应目录下的所有菜单，也可以通过 `show-year` 来控制是否需要展示年份