### PR TITLE
fix: configure Zeabur production server

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "packageManager": "pnpm@11.1.3",
   "scripts": {
     "build": "vite build",
+    "start": "srvx --prod --static ../client --entry dist/server/server.js",
     "dev": "vite dev --port 3000",
     "generate": "vite build",
     "preview": "vite preview",
@@ -31,6 +32,7 @@
     "remark-directive": "^4.0.0",
     "remark-gfm": "^4.0.1",
     "remark-supersub": "^1.0.0",
+    "srvx": "^0.11.22",
     "unist-util-visit": "^5.0.0",
     "yaml": "^2.9.0"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       remark-supersub:
         specifier: ^1.0.0
         version: 1.0.0
+      srvx:
+        specifier: ^0.11.22
+        version: 0.11.22
       unist-util-visit:
         specifier: ^5.0.0
         version: 5.1.0
@@ -1692,8 +1695,8 @@ packages:
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
 
-  srvx@0.11.16:
-    resolution: {integrity: sha512-bp07zRuycfTY43IjAvvTFnmnJi8ikW0VFiHwOhhYcVW/L4xQ1XY4PAd4Nuum1rsA17C39zL7x+CDhrn5AL32Rw==}
+  srvx@0.11.22:
+    resolution: {integrity: sha512-LqZxxBDMKuMAZzFzJnDCkFOrs9MZQZr0LvHiO/SuSZVdQaXD7xQ5UWTUxheJrQPve1qk9MG2B/yttUvJxw8egQ==}
     engines: {node: '>=20.16.0'}
     hasBin: true
 
@@ -2541,7 +2544,7 @@ snapshots:
       picomatch: 4.0.4
       seroval: 1.5.4
       source-map: 0.7.6
-      srvx: 0.11.16
+      srvx: 0.11.22
       tinyglobby: 0.2.17
       ufo: 1.6.4
       vitefu: 1.1.3(vite@8.1.5(@types/node@25.9.1)(jiti@2.7.0)(yaml@2.9.0))
@@ -2985,7 +2988,7 @@ snapshots:
   h3@2.0.1-rc.20:
     dependencies:
       rou3: 0.8.1
-      srvx: 0.11.16
+      srvx: 0.11.22
 
   hast-util-from-parse5@8.0.3:
     dependencies:
@@ -3841,7 +3844,7 @@ snapshots:
 
   sprintf-js@1.0.3: {}
 
-  srvx@0.11.16: {}
+  srvx@0.11.22: {}
 
   stackback@0.0.2: {}
 

--- a/src/content.test.ts
+++ b/src/content.test.ts
@@ -10,7 +10,7 @@ describe('content manifest', () => {
   })
 
   it('indexes every Markdown page without duplicate paths', () => {
-    expect(contentRecords).toHaveLength(142)
+    expect(contentRecords).toHaveLength(143)
     expect(new Set(contentRecords.map(record => record.path)).size).toBe(contentRecords.length)
     expect(getContent('/posts/building-cloud-agent-infrastructure')?.title).toBe('云上的 Agent，和本地有什么不同')
   })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,13 @@ import UnoCSS from 'unocss/vite'
 import { defineConfig } from 'vite'
 
 export default defineConfig({
+  build: {
+    rolldownOptions: {
+      output: {
+        assetFileNames: 'assets/[name][extname]',
+      },
+    },
+  },
   resolve: {
     tsconfigPaths: true,
   },

--- a/zbpack.json
+++ b/zbpack.json
@@ -1,0 +1,4 @@
+{
+  "build_command": "pnpm run build",
+  "start_command": "pnpm run start"
+}


### PR DESCRIPTION
## What changed

- Add an explicit Zeabur build and start configuration.
- Run the TanStack Start server bundle with `srvx` and serve `dist/client` as static assets.
- Use stable CSS asset filenames so server-rendered pages reference files that exist in the client build.
- Update the content count assertion for the newly added post.

## Why

The Nuxt deployment previously provided a production server automatically. After migrating to TanStack Start, Zeabur could complete the build but had no production start command, so no web process was available for preview. Hashed UnoCSS filenames also differed between the client and server builds, causing CSS requests to return 404.

## Impact

Zeabur can now build the site, start it on the provided `PORT`, serve static assets, and handle TanStack Start server routes.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test` (4 tests passed)
- `pnpm build` (144 pages prerendered)
- Production smoke test with a custom `PORT`: homepage, CSS, and favicon returned 200; newsletter API returned the expected JSON response.
